### PR TITLE
chore: bump GitHub Actions to latest Node24 runtimes (OPE-1020)

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -14,11 +14,11 @@ jobs:
       packages: write
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v7.0.0
       - name: Set up Go
-        uses: actions/setup-go@v2
+        uses: actions/setup-go@v6.5.0
         with:
-          go-version: 1.24
+          go-version-file: go.mod
       - name: Build
         run: go build -v ./...
       - name: Test
@@ -26,9 +26,9 @@ jobs:
   protolint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: bufbuild/buf-setup-action@v1.18.0
-      - uses: bufbuild/buf-lint-action@v1
-      - uses: bufbuild/buf-breaking-action@v1
+      - uses: actions/checkout@v7.0.0
+      - uses: bufbuild/buf-setup-action@v1.50.0
+      - uses: bufbuild/buf-lint-action@v1.1.1
+      - uses: bufbuild/buf-breaking-action@v1.1.4
         with:
           against: "https://github.com/${GITHUB_REPOSITORY}.git#branch=main"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,15 +14,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v7.0.0
         with:
           fetch-depth: 0
       - name: Set up Go 1.24
-        uses: actions/setup-go@v3
+        uses: actions/setup-go@v6.5.0
         with:
-          go-version: 1.24
+          go-version-file: go.mod
       - name: Run GoReleaser
-        uses: goreleaser/goreleaser-action@v4
+        uses: goreleaser/goreleaser-action@v7.2.3
         with:
           version: latest
           args: release


### PR DESCRIPTION
## Summary
Bumps every GitHub Actions `uses:` reference across `.github/workflows/` to its latest exact semver release, moving off the deprecated Node20 runtime (OPE-1020).

### Version bumps
| Action | From | To |
|---|---|---|
| actions/checkout | @v3 / @v2 | @v7.0.0 |
| actions/setup-go | @v2 / @v3 | @v6.5.0 |
| bufbuild/buf-setup-action | @v1.18.0 | @v1.50.0 |
| bufbuild/buf-lint-action | @v1 | @v1.1.1 |
| bufbuild/buf-breaking-action | @v1 | @v1.1.4 |
| goreleaser/goreleaser-action | @v4 | @v7.2.3 |

No `RedCarbon-Dev/rc-build-gh-actions` ref is present in this repo, so the @v0.15 pin does not apply here.

### Remediation
- **setup-go v6** forces `GOTOOLCHAIN=local`, disabling the toolchain auto-download that v2/v3 relied on. Both workflows pinned `go-version: 1.24`; replaced with `go-version-file: go.mod` (the repo has no `go.work`; `go.mod` declares `go 1.24`) so the toolchain stays in sync with the module requirement.

### Notes
- `release.yml` only runs on tag push (`v*`), so its `goreleaser` job will not run on this PR.
- Verified locally: `go build ./...` and `go test ./...` both pass.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)